### PR TITLE
feat: add emissary 3.9

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -51,6 +51,16 @@ updates:
           - "version-update:semver-major"
           - "version-update:semver-minor"
 
+  - package-ecosystem: "docker"
+    directory: "/1.5/3.9"
+    schedule:
+      interval: "daily"
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
+          - "version-update:semver-minor"
+
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/.github/workflows/artifacts.yaml
+++ b/.github/workflows/artifacts.yaml
@@ -20,6 +20,7 @@ jobs:
           - "3.4"
           - "3.5"
           - "3.6"
+          - "3.9"
 
     steps:
       - name: Checkout

--- a/1.5/3.9/Dockerfile
+++ b/1.5/3.9/Dockerfile
@@ -1,0 +1,34 @@
+FROM curiefense/curieproxy-envoy:v1.5.0 as curieproxy
+
+FROM docker.io/emissaryingress/emissary:3.9.1
+
+RUN set -xe && \
+  apk add lua pcre2 geoip vectorscan && \
+  apk --virtual .build-deps add python3 gcc g++ make unzip lua-dev luarocks pcre2-dev geoip-dev vectorscan-dev && \
+  ln -s $(which luarocks-5.1) /usr/local/bin/luarocks && \
+  luarocks install lrexlib-pcre2 && \
+  luarocks install lua-cjson && \
+  luarocks install lua-resty-string && \
+  luarocks install luafilesystem && \
+  luarocks install luasocket && \
+  luarocks install redis-lua && \
+  luarocks install compat53 && \
+  luarocks install mmdblua && \
+  luarocks install luaipc && \
+  luarocks install lua-resty-injection && \
+  unlink /usr/local/bin/luarocks && \
+  apk del .build-deps && \
+  rm -rf /var/cache/apk/*
+
+COPY --from=curieproxy /lua /ambassador/lua
+COPY --from=curieproxy /usr/local/lib/lua/5.1/*.so /usr/local/lib/lua/5.1/
+
+RUN ln -s /usr/lib/libhs.so.5 /usr/glibc-compat/lib/libhs.so.5
+RUN ln -s /usr/lib/libhs.so.5 /usr/glibc-compat/lib/libhs.so.4
+
+COPY --from=curieproxy --chown=ambassador:root /bootstrap-config/config /bootstrap-config/config
+
+RUN mkdir /cf-config && chmod a+rwxt /cf-config && chown ambassador.root /cf-config
+
+COPY entrypoint.sh /
+ENTRYPOINT /entrypoint.sh

--- a/1.5/3.9/entrypoint.sh
+++ b/1.5/3.9/entrypoint.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+if [ ! -e /cf-config/bootstrap ]; then
+	cp -va /bootstrap-config /cf-config/bootstrap
+fi
+
+if [ ! -e /cf-config/current ]; then
+	ln -s bootstrap /cf-config/current
+fi
+
+exec bash /buildroot/ambassador/python/entrypoint.sh


### PR DESCRIPTION
Elected to skip the missed versions in between 3.6 and 3.9 as there seems to be little benefit in backfilling them